### PR TITLE
feat(player): add preview playback for each album's intro

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "@/app/globals.css";
+import { PlaybackProvider } from "@/providers/PlaybackProvider";
 
 export const metadata: Metadata = {
   title: "Fevenir's Albums List",
@@ -13,7 +14,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <PlaybackProvider>{children}</PlaybackProvider>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,11 @@
 import AlbumList from "@/components/AlbumList";
+import PlaybackWidget from "@/components/PlaybackWidget";
 
 const IndexPage = async () => {
   return (
     <div className="flex flex-1 flex-col m-4 lg:m-8">
       <AlbumList layout="list" />
+      <PlaybackWidget />
     </div>
   );
 };

--- a/components/AlbumList.tsx
+++ b/components/AlbumList.tsx
@@ -8,6 +8,7 @@ interface AlbumListProps {
 
 const AlbumList = async ({ layout = "list" }: AlbumListProps) => {
   const albums = await getAllAlbums();
+  console.log(albums);
 
   return (
     <div>
@@ -29,6 +30,7 @@ const AlbumList = async ({ layout = "list" }: AlbumListProps) => {
             artistName={album.artistName}
             genreName={album.genreNames}
             artworkUrl={album.artworkUrl!}
+            firstSongUrl={album.firstSongUrl}
             layout={layout}
           />
         ))}

--- a/components/AlbumList.tsx
+++ b/components/AlbumList.tsx
@@ -30,6 +30,7 @@ const AlbumList = async ({ layout = "list" }: AlbumListProps) => {
             artistName={album.artistName}
             genreName={album.genreNames}
             artworkUrl={album.artworkUrl!}
+            firstSong={album.firstSong}
             firstSongUrl={album.firstSongUrl}
             layout={layout}
           />

--- a/components/PlaybackWidget.tsx
+++ b/components/PlaybackWidget.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 "use client";
+import Image from "next/image";
+import { usePlayback } from "@/providers/PlaybackProvider";
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Play, Pause, ChevronDown, ChevronUp, SkipBack, SkipForward, X } from "lucide-react";
-import { usePlayback } from "@/providers/PlaybackProvider";
-import Image from "next/image";
 
 export default function PlaybackWidget() {
   const {
@@ -56,9 +56,7 @@ export default function PlaybackWidget() {
           isExpanded ? "rounded-t-2xl" : "rounded-lg shadow-lg p-2"
         }`}
       >
-        <motion.div
-          className={`flex ${isExpanded ? "flex-col items-center h-full p-4" : "justify-between items-center"}`}
-        >
+        <div className={`flex ${isExpanded ? "flex-col items-center h-full p-4" : "justify-between items-center"}`}>
           {isExpanded ? (
             <>
               <motion.button onClick={() => setIsExpanded(false)} className="self-end">
@@ -66,79 +64,69 @@ export default function PlaybackWidget() {
               </motion.button>
 
               {currentAlbumCover && (
-                <motion.div>
-                  <Image
-                    src={currentAlbumCover}
-                    alt={`Cover art for ${currentAlbumName}`}
-                    height={300}
-                    width={300}
-                    className="rounded-lg shadow-md mt-4"
-                  />
-                </motion.div>
+                <Image
+                  src={currentAlbumCover}
+                  alt={`Cover art for ${currentAlbumName}`}
+                  height={300}
+                  width={300}
+                  className="rounded-lg shadow-md mt-4"
+                />
               )}
 
-              <motion.h2 className="text-lg font-semibold text-white mt-2">
-                {currentTrackName || "No track selected"}
-              </motion.h2>
-              <motion.p className="text-sm text-gray-300">{currentAlbumName || "Unknown Album"}</motion.p>
+              <h2 className="text-lg font-semibold text-white mt-2">{currentTrackName || "No track selected"}</h2>
+              <p className="text-sm text-gray-300">{currentAlbumName || "Unknown Album"}</p>
 
-              <motion.div className="flex gap-4 mt-4">
-                <motion.button onClick={prevTrack} className="text-white p-2">
+              <div className="flex gap-4 mt-4">
+                <button onClick={prevTrack} className="text-white p-2">
                   <SkipBack size={24} />
-                </motion.button>
-                <motion.button onClick={togglePlayPause} className="text-white p-2">
+                </button>
+                <button onClick={togglePlayPause} className="text-white p-2">
                   {isPlaying ? <Pause size={24} /> : <Play size={24} />}
-                </motion.button>
-                <motion.button onClick={nextTrack} className="text-white p-2">
+                </button>
+                <button onClick={nextTrack} className="text-white p-2">
                   <SkipForward size={24} />
-                </motion.button>
-              </motion.div>
+                </button>
+              </div>
             </>
           ) : (
-            <motion.div layout className="flex items-center w-full justify-between p-2">
+            <div className="flex items-center w-full justify-between p-2">
               {currentAlbumCover && (
-                <motion.div layout>
-                  <Image
-                    src={currentAlbumCover}
-                    alt={`Cover art for ${currentAlbumName}`}
-                    height={50}
-                    width={50}
-                    className="rounded-lg shadow-md"
-                  />
-                </motion.div>
+                <Image
+                  src={currentAlbumCover}
+                  alt={`Cover art for ${currentAlbumName}`}
+                  height={50}
+                  width={50}
+                  className="rounded-lg shadow-md"
+                />
               )}
-              <motion.div layout className="flex flex-col flex-1 ml-2">
-                <motion.h2 layout className="text-sm font-semibold text-white">
-                  {currentTrackName || "No track selected"}
-                </motion.h2>
-                <motion.p layout className="text-xs text-gray-300">
-                  {currentAlbumName || "Unknown Album"}
-                </motion.p>
-              </motion.div>
-              <motion.div layout className="flex items-center gap-2">
-                <motion.button layout onClick={prevTrack} className="text-white p-1">
+              <div className="flex-col ml-2 w-0 flex-1">
+                <h2 className="truncate font-semibold text-white">{currentTrackName || "No track selected"}</h2>
+                <p className="truncate text-gray-300">{currentAlbumName || "Unknown Album"}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button onClick={prevTrack} className="text-white p-1">
                   <SkipBack size={20} />
-                </motion.button>
-                <motion.button layout onClick={togglePlayPause} className="text-white p-1">
+                </button>
+                <button onClick={togglePlayPause} className="text-white p-1">
                   {isPlaying ? <Pause size={20} /> : <Play size={20} />}
-                </motion.button>
-                <motion.button layout onClick={nextTrack} className="text-white p-1">
+                </button>
+                <button onClick={nextTrack} className="text-white p-1">
                   <SkipForward size={20} />
-                </motion.button>
-              </motion.div>
-              <motion.button layout onClick={() => setIsExpanded(true)} className="text-white ml-2">
+                </button>
+              </div>
+              <button onClick={() => setIsExpanded(true)} className="text-white ml-2">
                 <ChevronUp size={24} />
-              </motion.button>
-              <motion.button layout onClick={() => setIsVisible(false)} className="text-white ml-2">
+              </button>
+              <button onClick={() => setIsVisible(false)} className="text-white ml-2">
                 <X size={24} />
-              </motion.button>
-            </motion.div>
+              </button>
+            </div>
           )}
           <audio ref={audioRef} className="w-full">
             <source src={currentTrack} type="audio/mp4" />
             Your browser does not support the audio element.
           </audio>
-        </motion.div>
+        </div>
       </motion.div>
     </AnimatePresence>
   );

--- a/components/PlaybackWidget.tsx
+++ b/components/PlaybackWidget.tsx
@@ -100,7 +100,7 @@ export default function PlaybackWidget() {
                 <motion.div layout>
                   <Image
                     src={currentAlbumCover}
-                    alt="Album Cover"
+                    alt={`Cover art for ${currentAlbumName}`}
                     height={50}
                     width={50}
                     className="rounded-lg shadow-md"

--- a/components/PlaybackWidget.tsx
+++ b/components/PlaybackWidget.tsx
@@ -1,0 +1,80 @@
+"use client";
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Play, Pause, ChevronDown, ChevronUp } from "lucide-react";
+import { usePlayback } from "@/providers/PlaybackProvider";
+
+export default function PlaybackWidget() {
+  const { currentTrack, currentTrackName, setTrack, isPlaying, togglePlayPause, audioRef } = usePlayback();
+  const [isOpen, setIsOpen] = useState(false);
+  const [wasMinimized, setWasMinimized] = useState(false);
+
+  useEffect(() => {
+    if (currentTrack) {
+      if (!isOpen && !wasMinimized) {
+        setIsOpen(true);
+      }
+    } else {
+      setIsOpen(false);
+    }
+  }, [currentTrack, isOpen, wasMinimized]);
+
+  return (
+    <>
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            initial={{ y: "100%" }}
+            animate={{ y: 0 }}
+            exit={{ y: "100%" }}
+            transition={{ type: "spring", stiffness: 120, damping: 15 }}
+            className="fixed bottom-0 left-0 right-0 h-[60vh] bg-gray-900 shadow-xl rounded-t-2xl p-4"
+          >
+            <div className="flex flex-col items-center">
+              <button
+                onClick={() => {
+                  setIsOpen(false);
+                  setWasMinimized(true);
+                }}
+                className="self-end"
+              >
+                <ChevronDown size={24} />
+              </button>
+              <h2 className="text-lg font-semibold">Now Playing</h2>
+              <p className="text-center text-black text-sm">{currentTrackName || "No track selected"}</p>
+              <div className="flex gap-4 mt-2">
+                <button onClick={togglePlayPause} className="bg-gray-900 text-white p-2 rounded-full">
+                  {isPlaying ? <Pause size={24} /> : <Play size={24} />}
+                </button>
+                <button onClick={() => setTrack(null, null)} className="bg-red-500 text-white px-4 py-2 rounded-lg">
+                  Stop
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {currentTrack && (
+        <motion.div
+          initial={{ y: 100 }}
+          animate={{ y: 0 }}
+          exit={{ y: 100 }}
+          transition={{ type: "spring", stiffness: 120, damping: 15 }}
+          className="fixed bottom-4 left-4 right-4 bg-gray-900 text-white flex justify-between items-center px-4 py-2 rounded-lg shadow-lg"
+        >
+          <audio ref={audioRef} controls autoPlay className="w-full">
+            <source src={currentTrack} type="audio/mp4" />
+            Your browser does not support the audio element.
+          </audio>
+          <button onClick={() => setIsOpen(true)} className="text-white">
+            <ChevronUp size={24} />
+          </button>
+          <button onClick={togglePlayPause} className="bg-white text-gray-900 p-2 rounded-full">
+            {isPlaying ? <Pause size={24} /> : <Play size={24} />}
+          </button>
+        </motion.div>
+      )}
+    </>
+  );
+}

--- a/components/PlaybackWidget.tsx
+++ b/components/PlaybackWidget.tsx
@@ -2,11 +2,23 @@
 "use client";
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Play, Pause, ChevronDown, ChevronUp, SkipBack, SkipForward } from "lucide-react";
+import { Play, Pause, ChevronDown, ChevronUp, SkipBack, SkipForward, X } from "lucide-react";
 import { usePlayback } from "@/providers/PlaybackProvider";
+import Image from "next/image";
 
 export default function PlaybackWidget() {
-  const { currentTrack, currentTrackName, isPlaying, togglePlayPause, audioRef, nextTrack, prevTrack } = usePlayback();
+  const {
+    currentTrack,
+    currentTrackName,
+    currentAlbumCover,
+    currentAlbumName,
+    isPlaying,
+    togglePlayPause,
+    audioRef,
+    nextTrack,
+    prevTrack,
+  } = usePlayback();
+
   const [isExpanded, setIsExpanded] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const [wasClosed, setWasClosed] = useState(true);
@@ -20,10 +32,9 @@ export default function PlaybackWidget() {
       }
     } else {
       setIsVisible(false);
-      setIsExpanded(false);
       setWasClosed(true);
     }
-  }, [currentTrack, isVisible]);
+  }, [currentTrack]);
 
   useEffect(() => {
     if (isExpanded && wasClosed && audioRef.current) {
@@ -38,59 +49,96 @@ export default function PlaybackWidget() {
     <AnimatePresence>
       <motion.div
         initial={{ y: "100%" }}
-        animate={{
-          y: 0,
-          height: isExpanded ? "60vh" : "auto",
-        }}
+        animate={{ y: 0, height: isExpanded ? "60vh" : "auto" }}
         exit={{ y: "100%" }}
-        transition={{
-          type: "tween",
-          duration: 0.3,
-          ease: "easeInOut",
-        }}
-        className={`fixed bg-gray-800 shadow-xl text-white ${
-          isExpanded ? "bottom-0 left-0 right-0 rounded-t-2xl" : "rounded-lg shadow-lg bottom-0 left-0 right-0"
+        transition={{ type: "tween", duration: 0.2, ease: isExpanded ? "easeInOut" : "easeIn" }}
+        className={`fixed bg-[#1c1c1c] shadow-xl text-white bottom-0 left-0 right-0 ${
+          isExpanded ? "rounded-t-2xl" : "rounded-lg shadow-lg p-2"
         }`}
       >
-        <div className={`flex ${isExpanded ? "flex-col items-center h-full" : "justify-between items-center"}`}>
-          {isExpanded && (
+        <motion.div
+          className={`flex ${isExpanded ? "flex-col items-center h-full p-4" : "justify-between items-center"}`}
+        >
+          {isExpanded ? (
             <>
-              <button
-                onClick={() => {
-                  setIsExpanded(false);
-                }}
-                className="self-end"
-              >
+              <motion.button onClick={() => setIsExpanded(false)} className="self-end">
                 <ChevronDown size={24} className="text-white" />
-              </button>
-              <h2 className="text-lg font-semibold text-white">Now Playing</h2>
-              <p className="text-center text-white text-sm">{currentTrackName || "No track selected"}</p>
-              <div className="flex gap-4">
-                <button onClick={togglePlayPause} className="bg-gray-900 text-white p-2 rounded-full">
-                  {isPlaying ? <Pause size={24} /> : <Play size={24} />}
-                </button>
-                <button onClick={prevTrack} className="text-white p-2">
-                  <SkipBack size={24} />
-                </button>
-                <button onClick={nextTrack} className="text-white p-2">
-                  <SkipForward size={24} />
-                </button>
-              </div>
-            </>
-          )}
+              </motion.button>
 
-          <div className="absolute bottom-0 left-0 right-0 w-full bg-gray-800 p-4 flex justify-between items-center">
-            <div className="flex flex-1">
-              <audio ref={audioRef} className="w-full" controls>
-                <source src={currentTrack} type="audio/mp4" />
-                Your browser does not support the audio element.
-              </audio>
-            </div>
-            <button onClick={() => setIsExpanded(true)} className="text-white ml-2">
-              <ChevronUp size={24} />
-            </button>
-          </div>
-        </div>
+              {currentAlbumCover && (
+                <motion.div>
+                  <Image
+                    src={currentAlbumCover}
+                    alt={`Cover art for ${currentAlbumName}`}
+                    height={300}
+                    width={300}
+                    className="rounded-lg shadow-md mt-4"
+                  />
+                </motion.div>
+              )}
+
+              <motion.h2 className="text-lg font-semibold text-white mt-2">
+                {currentTrackName || "No track selected"}
+              </motion.h2>
+              <motion.p className="text-sm text-gray-300">{currentAlbumName || "Unknown Album"}</motion.p>
+
+              <motion.div className="flex gap-4 mt-4">
+                <motion.button onClick={prevTrack} className="text-white p-2">
+                  <SkipBack size={24} />
+                </motion.button>
+                <motion.button onClick={togglePlayPause} className="text-white p-2">
+                  {isPlaying ? <Pause size={24} /> : <Play size={24} />}
+                </motion.button>
+                <motion.button onClick={nextTrack} className="text-white p-2">
+                  <SkipForward size={24} />
+                </motion.button>
+              </motion.div>
+            </>
+          ) : (
+            <motion.div layout className="flex items-center w-full justify-between p-2">
+              {currentAlbumCover && (
+                <motion.div layout>
+                  <Image
+                    src={currentAlbumCover}
+                    alt="Album Cover"
+                    height={50}
+                    width={50}
+                    className="rounded-lg shadow-md"
+                  />
+                </motion.div>
+              )}
+              <motion.div layout className="flex flex-col flex-1 ml-2">
+                <motion.h2 layout className="text-sm font-semibold text-white">
+                  {currentTrackName || "No track selected"}
+                </motion.h2>
+                <motion.p layout className="text-xs text-gray-300">
+                  {currentAlbumName || "Unknown Album"}
+                </motion.p>
+              </motion.div>
+              <motion.div layout className="flex items-center gap-2">
+                <motion.button layout onClick={prevTrack} className="text-white p-1">
+                  <SkipBack size={20} />
+                </motion.button>
+                <motion.button layout onClick={togglePlayPause} className="text-white p-1">
+                  {isPlaying ? <Pause size={20} /> : <Play size={20} />}
+                </motion.button>
+                <motion.button layout onClick={nextTrack} className="text-white p-1">
+                  <SkipForward size={20} />
+                </motion.button>
+              </motion.div>
+              <motion.button layout onClick={() => setIsExpanded(true)} className="text-white ml-2">
+                <ChevronUp size={24} />
+              </motion.button>
+              <motion.button layout onClick={() => setIsVisible(false)} className="text-white ml-2">
+                <X size={24} />
+              </motion.button>
+            </motion.div>
+          )}
+          <audio ref={audioRef} className="w-full">
+            <source src={currentTrack} type="audio/mp4" />
+            Your browser does not support the audio element.
+          </audio>
+        </motion.div>
       </motion.div>
     </AnimatePresence>
   );

--- a/components/PlaybackWidget.tsx
+++ b/components/PlaybackWidget.tsx
@@ -1,80 +1,97 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 "use client";
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Play, Pause, ChevronDown, ChevronUp } from "lucide-react";
+import { Play, Pause, ChevronDown, ChevronUp, SkipBack, SkipForward } from "lucide-react";
 import { usePlayback } from "@/providers/PlaybackProvider";
 
 export default function PlaybackWidget() {
-  const { currentTrack, currentTrackName, setTrack, isPlaying, togglePlayPause, audioRef } = usePlayback();
-  const [isOpen, setIsOpen] = useState(false);
-  const [wasMinimized, setWasMinimized] = useState(false);
+  const { currentTrack, currentTrackName, isPlaying, togglePlayPause, audioRef, nextTrack, prevTrack } = usePlayback();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const [wasClosed, setWasClosed] = useState(true);
 
   useEffect(() => {
     if (currentTrack) {
-      if (!isOpen && !wasMinimized) {
-        setIsOpen(true);
+      if (!isVisible) {
+        setIsVisible(true);
+        setIsExpanded(true);
+        setWasClosed(true);
       }
     } else {
-      setIsOpen(false);
+      setIsVisible(false);
+      setIsExpanded(false);
+      setWasClosed(true);
     }
-  }, [currentTrack, isOpen, wasMinimized]);
+  }, [currentTrack, isVisible]);
+
+  useEffect(() => {
+    if (isExpanded && wasClosed && audioRef.current) {
+      audioRef.current.play();
+      setWasClosed(false);
+    }
+  }, [isExpanded, wasClosed]);
+
+  if (!isVisible || !currentTrack) return null;
 
   return (
-    <>
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            initial={{ y: "100%" }}
-            animate={{ y: 0 }}
-            exit={{ y: "100%" }}
-            transition={{ type: "spring", stiffness: 120, damping: 15 }}
-            className="fixed bottom-0 left-0 right-0 h-[60vh] bg-gray-900 shadow-xl rounded-t-2xl p-4"
-          >
-            <div className="flex flex-col items-center">
+    <AnimatePresence>
+      <motion.div
+        initial={{ y: "100%" }}
+        animate={{
+          y: 0,
+          height: isExpanded ? "60vh" : "auto",
+        }}
+        exit={{ y: "100%" }}
+        transition={{
+          type: "tween",
+          duration: 0.3,
+          ease: "easeInOut",
+        }}
+        className={`fixed bg-gray-800 shadow-xl text-white ${
+          isExpanded ? "bottom-0 left-0 right-0 rounded-t-2xl" : "rounded-lg shadow-lg bottom-0 left-0 right-0"
+        }`}
+      >
+        <div className={`flex ${isExpanded ? "flex-col items-center h-full" : "justify-between items-center"}`}>
+          {isExpanded && (
+            <>
               <button
                 onClick={() => {
-                  setIsOpen(false);
-                  setWasMinimized(true);
+                  setIsExpanded(false);
                 }}
                 className="self-end"
               >
-                <ChevronDown size={24} />
+                <ChevronDown size={24} className="text-white" />
               </button>
-              <h2 className="text-lg font-semibold">Now Playing</h2>
-              <p className="text-center text-black text-sm">{currentTrackName || "No track selected"}</p>
-              <div className="flex gap-4 mt-2">
+              <h2 className="text-lg font-semibold text-white">Now Playing</h2>
+              <p className="text-center text-white text-sm">{currentTrackName || "No track selected"}</p>
+              <div className="flex gap-4">
                 <button onClick={togglePlayPause} className="bg-gray-900 text-white p-2 rounded-full">
                   {isPlaying ? <Pause size={24} /> : <Play size={24} />}
                 </button>
-                <button onClick={() => setTrack(null, null)} className="bg-red-500 text-white px-4 py-2 rounded-lg">
-                  Stop
+                <button onClick={prevTrack} className="text-white p-2">
+                  <SkipBack size={24} />
+                </button>
+                <button onClick={nextTrack} className="text-white p-2">
+                  <SkipForward size={24} />
                 </button>
               </div>
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+            </>
+          )}
 
-      {currentTrack && (
-        <motion.div
-          initial={{ y: 100 }}
-          animate={{ y: 0 }}
-          exit={{ y: 100 }}
-          transition={{ type: "spring", stiffness: 120, damping: 15 }}
-          className="fixed bottom-4 left-4 right-4 bg-gray-900 text-white flex justify-between items-center px-4 py-2 rounded-lg shadow-lg"
-        >
-          <audio ref={audioRef} controls autoPlay className="w-full">
-            <source src={currentTrack} type="audio/mp4" />
-            Your browser does not support the audio element.
-          </audio>
-          <button onClick={() => setIsOpen(true)} className="text-white">
-            <ChevronUp size={24} />
-          </button>
-          <button onClick={togglePlayPause} className="bg-white text-gray-900 p-2 rounded-full">
-            {isPlaying ? <Pause size={24} /> : <Play size={24} />}
-          </button>
-        </motion.div>
-      )}
-    </>
+          <div className="absolute bottom-0 left-0 right-0 w-full bg-gray-800 p-4 flex justify-between items-center">
+            <div className="flex flex-1">
+              <audio ref={audioRef} className="w-full" controls>
+                <source src={currentTrack} type="audio/mp4" />
+                Your browser does not support the audio element.
+              </audio>
+            </div>
+            <button onClick={() => setIsExpanded(true)} className="text-white ml-2">
+              <ChevronUp size={24} />
+            </button>
+          </div>
+        </div>
+      </motion.div>
+    </AnimatePresence>
   );
 }

--- a/components/ui/AlbumCard.tsx
+++ b/components/ui/AlbumCard.tsx
@@ -7,40 +7,49 @@ interface AlbumCardProps {
   artistName: string[];
   genreName: string[];
   artworkUrl: string;
+  firstSongUrl: string | null;
   layout?: "list" | "grid";
 }
 
-export const AlbumCard = ({ index, name, artistName, artworkUrl, layout = "list" }: AlbumCardProps) => {
+export const AlbumCard = ({ index, name, artistName, artworkUrl, firstSongUrl, layout = "list" }: AlbumCardProps) => {
   return (
-    <div
-      className={`
+    <>
+      <div
+        className={`
         ${
           layout === "list"
             ? "flex flex-row gap-4 items-center bg-white/5 p-4 rounded-lg hover:bg-white/10 transition-colors duration-300"
             : "bg-white/5 rounded-lg overflow-hidden hover:bg-white/10 transition-colors duration-300"
         }
-      `}
-    >
-      {layout === "list" && (
-        <div className="w-8 lg:w-16 text-xl text-center flex-shrink-0">
-          <p>{index! + 1}</p>
+        `}
+      >
+        {layout === "list" && (
+          <div className="w-8 lg:w-16 text-xl text-center flex-shrink-0">
+            <p>{index! + 1}</p>
+          </div>
+        )}
+        <div className={layout === "list" ? "flex-shrink-0" : "aspect-square"}>
+          <Image
+            src={artworkUrl}
+            width={layout === "list" ? 50 : 300}
+            height={layout === "list" ? 50 : 300}
+            alt={`Album cover for ${name} by ${artistName}`}
+            className={layout === "list" ? "rounded-md" : "w-full h-full object-cover"}
+          />
         </div>
+        <div className={`flex flex-1 flex-col min-w-0 ${layout === "grid" ? "p-4" : ""}`}>
+          <p className={`truncate ${layout === "grid" ? "text-center text-lg" : "text-xl"}`}>{name}</p>
+          <p className={`truncate text-red-500 ${layout === "grid" ? "text-center text-md" : ""}`}>
+            {artistName.join(", ")}
+          </p>
+        </div>
+      </div>
+      {firstSongUrl && (
+        <audio controls>
+          <source src={firstSongUrl} type="audio/mp4" />
+          Your browser does not support the audio element.
+        </audio>
       )}
-      <div className={layout === "list" ? "flex-shrink-0" : "aspect-square"}>
-        <Image
-          src={artworkUrl}
-          width={layout === "list" ? 50 : 300}
-          height={layout === "list" ? 50 : 300}
-          alt={`Album cover for ${name} by ${artistName}`}
-          className={layout === "list" ? "rounded-md" : "w-full h-full object-cover"}
-        />
-      </div>
-      <div className={`flex flex-1 flex-col min-w-0 ${layout === "grid" ? "p-4" : ""}`}>
-        <p className={`truncate ${layout === "grid" ? "text-center text-lg" : "text-xl"}`}>{name}</p>
-        <p className={`truncate text-red-500 ${layout === "grid" ? "text-center text-md" : ""}`}>
-          {artistName.join(", ")}
-        </p>
-      </div>
-    </div>
+    </>
   );
 };

--- a/components/ui/AlbumCard.tsx
+++ b/components/ui/AlbumCard.tsx
@@ -9,11 +9,20 @@ interface AlbumCardProps {
   artistName: string[];
   genreName: string[];
   artworkUrl: string;
+  firstSong: string | null;
   firstSongUrl: string | null;
   layout?: "list" | "grid";
 }
 
-export const AlbumCard = ({ index, name, artistName, artworkUrl, firstSongUrl, layout = "list" }: AlbumCardProps) => {
+export const AlbumCard = ({
+  index,
+  name,
+  artistName,
+  artworkUrl,
+  firstSong,
+  firstSongUrl,
+  layout = "list",
+}: AlbumCardProps) => {
   const { setTrack } = usePlayback();
 
   return (
@@ -23,7 +32,7 @@ export const AlbumCard = ({ index, name, artistName, artworkUrl, firstSongUrl, l
           ? "flex flex-row gap-4 items-center bg-white/5 p-4 rounded-lg hover:bg-white/10 transition-colors duration-300"
           : "bg-white/5 rounded-lg overflow-hidden hover:bg-white/10 transition-colors duration-300"
       }`}
-      onClick={() => firstSongUrl && setTrack(firstSongUrl)}
+      onClick={() => firstSongUrl && setTrack(firstSongUrl, firstSong)}
     >
       {layout === "list" && (
         <div className="w-8 lg:w-16 text-xl text-center flex-shrink-0">

--- a/components/ui/AlbumCard.tsx
+++ b/components/ui/AlbumCard.tsx
@@ -44,7 +44,7 @@ export const AlbumCard = ({
           src={artworkUrl}
           width={layout === "list" ? 50 : 300}
           height={layout === "list" ? 50 : 300}
-          alt={`Album cover for ${name} by ${artistName.join(", ")}`}
+          alt={`Cover art for ${name}`}
           className={layout === "list" ? "rounded-md" : "w-full h-full object-cover"}
         />
       </div>

--- a/components/ui/AlbumCard.tsx
+++ b/components/ui/AlbumCard.tsx
@@ -32,7 +32,7 @@ export const AlbumCard = ({
           ? "flex flex-row gap-4 items-center bg-white/5 p-4 rounded-lg hover:bg-white/10 transition-colors duration-300"
           : "bg-white/5 rounded-lg overflow-hidden hover:bg-white/10 transition-colors duration-300"
       }`}
-      onClick={() => firstSongUrl && setTrack(firstSongUrl, firstSong)}
+      onClick={() => firstSongUrl && setTrack(firstSongUrl, firstSong, artworkUrl, name)}
     >
       {layout === "list" && (
         <div className="w-8 lg:w-16 text-xl text-center flex-shrink-0">

--- a/components/ui/AlbumCard.tsx
+++ b/components/ui/AlbumCard.tsx
@@ -1,5 +1,7 @@
+"use client";
 import Image from "next/image";
 import React from "react";
+import { usePlayback } from "@/providers/PlaybackProvider";
 
 interface AlbumCardProps {
   index?: number;
@@ -12,44 +14,37 @@ interface AlbumCardProps {
 }
 
 export const AlbumCard = ({ index, name, artistName, artworkUrl, firstSongUrl, layout = "list" }: AlbumCardProps) => {
+  const { setTrack } = usePlayback();
+
   return (
-    <>
-      <div
-        className={`
-        ${
-          layout === "list"
-            ? "flex flex-row gap-4 items-center bg-white/5 p-4 rounded-lg hover:bg-white/10 transition-colors duration-300"
-            : "bg-white/5 rounded-lg overflow-hidden hover:bg-white/10 transition-colors duration-300"
-        }
-        `}
-      >
-        {layout === "list" && (
-          <div className="w-8 lg:w-16 text-xl text-center flex-shrink-0">
-            <p>{index! + 1}</p>
-          </div>
-        )}
-        <div className={layout === "list" ? "flex-shrink-0" : "aspect-square"}>
-          <Image
-            src={artworkUrl}
-            width={layout === "list" ? 50 : 300}
-            height={layout === "list" ? 50 : 300}
-            alt={`Album cover for ${name} by ${artistName}`}
-            className={layout === "list" ? "rounded-md" : "w-full h-full object-cover"}
-          />
+    <div
+      className={`cursor-pointer ${
+        layout === "list"
+          ? "flex flex-row gap-4 items-center bg-white/5 p-4 rounded-lg hover:bg-white/10 transition-colors duration-300"
+          : "bg-white/5 rounded-lg overflow-hidden hover:bg-white/10 transition-colors duration-300"
+      }`}
+      onClick={() => firstSongUrl && setTrack(firstSongUrl)}
+    >
+      {layout === "list" && (
+        <div className="w-8 lg:w-16 text-xl text-center flex-shrink-0">
+          <p>{index! + 1}</p>
         </div>
-        <div className={`flex flex-1 flex-col min-w-0 ${layout === "grid" ? "p-4" : ""}`}>
-          <p className={`truncate ${layout === "grid" ? "text-center text-lg" : "text-xl"}`}>{name}</p>
-          <p className={`truncate text-red-500 ${layout === "grid" ? "text-center text-md" : ""}`}>
-            {artistName.join(", ")}
-          </p>
-        </div>
-      </div>
-      {firstSongUrl && (
-        <audio controls>
-          <source src={firstSongUrl} type="audio/mp4" />
-          Your browser does not support the audio element.
-        </audio>
       )}
-    </>
+      <div className={layout === "list" ? "flex-shrink-0" : "aspect-square"}>
+        <Image
+          src={artworkUrl}
+          width={layout === "list" ? 50 : 300}
+          height={layout === "list" ? 50 : 300}
+          alt={`Album cover for ${name} by ${artistName.join(", ")}`}
+          className={layout === "list" ? "rounded-md" : "w-full h-full object-cover"}
+        />
+      </div>
+      <div className={`flex flex-1 flex-col min-w-0 ${layout === "grid" ? "p-4" : ""}`}>
+        <p className={`truncate ${layout === "grid" ? "text-center text-lg" : "text-xl"}`}>{name}</p>
+        <p className={`truncate text-red-500 ${layout === "grid" ? "text-center text-md" : ""}`}>
+          {artistName.join(", ")}
+        </p>
+      </div>
+    </div>
   );
 };

--- a/db/actions/albumsAction.ts
+++ b/db/actions/albumsAction.ts
@@ -12,6 +12,8 @@ export const getAllAlbums = async () => {
       genreNames: albums.genreNames,
       releaseDate: albums.releaseDate,
       artworkUrl: albums.artworkUrl,
+      firstSong: albums.firstSong,
+      firstSongUrl: albums.firstSongUrl,
     })
     .from(albums)
     .orderBy(sql`lower(${albums.artistName}[1])`, asc(albums.releaseDate));

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -24,6 +24,8 @@ export const albums = pgTable("albums", {
   isSingle: boolean("is_single"),
   isCompilation: boolean("is_compilation"),
   isComplete: boolean("is_complete"),
+  firstSong: varchar("first_song", { length: 255 }),
+  firstSongUrl: text("first_song_url"),
 });
 
 export const perfectAlbums = pgTable(

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^16.4.5",
         "drizzle-orm": "^0.36.4",
         "framer-motion": "^11.12.0",
+        "lucide-react": "^0.483.0",
         "next": "15.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4993,6 +4994,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.483.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.483.0.tgz",
+      "integrity": "sha512-WldsY17Qb/T3VZdMnVQ9C3DDIP7h1ViDTHVdVGnLZcvHNg30zH/MTQ04RTORjexoGmpsXroiQXZ4QyR0kBy0FA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.36.4",
     "framer-motion": "^11.12.0",
+    "lucide-react": "^0.483.0",
     "next": "15.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/providers/PlaybackProvider.tsx
+++ b/providers/PlaybackProvider.tsx
@@ -1,30 +1,59 @@
 "use client";
 import React, { createContext, useContext, useState, ReactNode, useRef } from "react";
+import { getAllAlbums } from "@/db/actions/albumsAction"; // Ensure correct path
+
+interface Track {
+  url: string | null;
+  name: string | null;
+}
 
 interface PlaybackContextType {
   currentTrack: string | null;
   currentTrackName: string | null;
-  setTrack: (url: string | null, name: string | null) => void;
+  trackList: Track[];
+  currentIndex: number;
+  setTrack: (url: string | null, name: string | null, index?: number) => void;
   isPlaying: boolean;
   togglePlayPause: () => void;
+  nextTrack: () => void;
+  prevTrack: () => void;
   audioRef: React.RefObject<HTMLAudioElement>;
 }
 
 const PlaybackContext = createContext<PlaybackContextType | undefined>(undefined);
 
 export const PlaybackProvider = ({ children }: { children: ReactNode }) => {
+  const [trackList, setTrackList] = useState<Track[]>([]);
+  const [currentIndex, setCurrentIndex] = useState<number>(-1);
   const [currentTrack, setCurrentTrack] = useState<string | null>(null);
   const [currentTrackName, setCurrentTrackName] = useState<string | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
-  const playTrack = (url: string | null, name: string | null) => {
+  React.useEffect(() => {
+    console.log(currentIndex);
+  }, [currentIndex]);
+
+  // Fetch albums and set trackList
+  React.useEffect(() => {
+    getAllAlbums().then((albums) => {
+      const tracks = albums
+        .filter((album) => album.firstSongUrl && album.firstSong)
+        .map((album) => ({
+          url: album.firstSongUrl,
+          name: album.firstSong,
+        }));
+      setTrackList(tracks);
+    });
+  }, []);
+
+  const playTrack = (url: string | null, name: string | null, index?: number) => {
     if (audioRef.current) {
-      audioRef.current.pause(); // Stop previous track
-      audioRef.current.src = url || ""; // Reset the src to force reload
-      audioRef.current.load(); // Load new track
+      audioRef.current.pause();
+      audioRef.current.src = url || "";
+      audioRef.current.load();
       if (url) {
-        audioRef.current.play(); // Start playback
+        audioRef.current.play();
         setIsPlaying(true);
       } else {
         setIsPlaying(false);
@@ -32,6 +61,9 @@ export const PlaybackProvider = ({ children }: { children: ReactNode }) => {
     }
     setCurrentTrack(url);
     setCurrentTrackName(name);
+
+    index = trackList.findIndex((track) => track.url === url);
+    setCurrentIndex(index);
   };
 
   const togglePlayPause = () => {
@@ -45,9 +77,36 @@ export const PlaybackProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
+  const nextTrack = () => {
+    if (trackList.length === 0) return;
+    const nextIndex = (currentIndex + 1) % trackList.length;
+    playTrack(trackList[nextIndex].url, trackList[nextIndex].name, nextIndex);
+  };
+
+  const prevTrack = () => {
+    if (trackList.length === 0 || !audioRef.current) return;
+    if (audioRef.current.currentTime > 3) {
+      audioRef.current.currentTime = 0; // Restart current track
+    } else {
+      const prevIndex = (currentIndex - 1 + trackList.length) % trackList.length;
+      playTrack(trackList[prevIndex].url, trackList[prevIndex].name, prevIndex);
+    }
+  };
+
   return (
     <PlaybackContext.Provider
-      value={{ currentTrack, currentTrackName, setTrack: playTrack, isPlaying, togglePlayPause, audioRef }}
+      value={{
+        currentTrack,
+        currentTrackName,
+        trackList,
+        currentIndex,
+        setTrack: playTrack,
+        isPlaying,
+        togglePlayPause,
+        nextTrack,
+        prevTrack,
+        audioRef,
+      }}
     >
       {children}
     </PlaybackContext.Provider>

--- a/providers/PlaybackProvider.tsx
+++ b/providers/PlaybackProvider.tsx
@@ -1,0 +1,51 @@
+"use client";
+import React, { createContext, useContext, useState, ReactNode, useRef } from "react";
+
+interface PlaybackContextType {
+  currentTrack: string | null;
+  setTrack: (url: string | null) => void;
+}
+
+const PlaybackContext = createContext<PlaybackContextType | undefined>(undefined);
+
+export const PlaybackProvider = ({ children }: { children: ReactNode }) => {
+  const [currentTrack, setCurrentTrack] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const playTrack = (url: string | null) => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.load();
+    }
+    setCurrentTrack(url);
+  };
+
+  return (
+    <PlaybackContext.Provider value={{ currentTrack, setTrack: playTrack }}>
+      <div className="fixed top-0 left-0 w-full bg-black text-white p-4 z-50 flex items-center justify-between">
+        {currentTrack ? (
+          <audio ref={audioRef} controls autoPlay className="w-full">
+            <source src={currentTrack} type="audio/mp4" />
+            Your browser does not support the audio element.
+          </audio>
+        ) : (
+          <p className="text-center">Select a track to play</p>
+        )}
+        {currentTrack && (
+          <button onClick={() => playTrack(null)} className="ml-4 px-4 py-2 bg-red-500 rounded-lg">
+            Stop
+          </button>
+        )}
+      </div>
+      <div className="mt-20">{children}</div>
+    </PlaybackContext.Provider>
+  );
+};
+
+export const usePlayback = () => {
+  const context = useContext(PlaybackContext);
+  if (!context) {
+    throw new Error("usePlayback must be used within a PlaybackProvider");
+  }
+  return context;
+};

--- a/providers/PlaybackProvider.tsx
+++ b/providers/PlaybackProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
-import React, { createContext, useContext, useState, ReactNode, useRef } from "react";
-import { getAllAlbums } from "@/db/actions/albumsAction"; // Ensure correct path
+import { getAllAlbums } from "@/db/actions/albumsAction";
+import React, { createContext, useContext, useState, ReactNode, useRef, useEffect } from "react";
 
 interface Track {
   url: string | null;
@@ -42,11 +42,11 @@ export const PlaybackProvider = ({ children }: { children: ReactNode }) => {
   const [isPlaying, setIsPlaying] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     console.log(currentIndex);
   }, [currentIndex]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     getAllAlbums().then((albums) => {
       const tracks = albums
         .filter((album) => album.firstSongUrl && album.firstSong)

--- a/types/albums.ts
+++ b/types/albums.ts
@@ -22,4 +22,6 @@ export type Album = {
   is_single: boolean;
   is_compilation: boolean;
   is_complete: boolean;
+  first_song: string | null;
+  first_song_url: string | null;
 };


### PR DESCRIPTION
# Changelog
### Database
- Schema was updated to contain firstSong and firstSongUrl fields. This was done to maintain the current functionality of the website with Incremental Static Regeneration: We can fetch the preview URLs from the db and have the page cached everytime a db update is made. This ensures the website itself loads and works quick.
- The fields in the database were updated using a separate node function to automate it.
### UI
- Added Playback Widget with closed, minimized and expanded states to play the preview songs.
- Added a Playback Provider using React Context to maintain the state of the current playing/not playing songs.
### Functionality
- The playback goes through all the intro tracks, and loops around. (Going forward from last album brings you to first album and vice versa.)
- If over 3 seconds of a song has been played, going backwards will repeat the song. Otherwise, it will go to the previous song.
- Added a Playback Provider using React Context to maintain the state of the current playing/not playing songs.
- Widget itself takes part of the screen in expanded view (similar to a mobile bottom sheet drawer), and collapses into a minimised now-playing widget, and can be closed from this state.
- The functionality of the rest of the website has not been altered.

Albums with the following IDs are currently broken: [1781244420, 1476084512, 1729895360, 1732096585, 349736310, 1215408950, 1781244912]. This is because of the album being republished after it being added to the database, or similar reasons, which changed the id versus what is stored in the database. These 7 albums would need manual updation due to this. Added checks to ensure forward/backward controls avoid the seven null previews.
